### PR TITLE
Drop odlparent to 3.1.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -19,10 +19,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>org.opendaylight.odlparent</groupId>
-      <artifactId>odlparent-lite</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
-      <relativePath/>
+        <groupId>org.opendaylight.odlparent</groupId>
+        <artifactId>odlparent-lite</artifactId>
+        <version>3.1.3</version>
+        <relativePath/>
     </parent>
 
     <groupId>tech.pantheon.triemap</groupId>

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bundle-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>3.1.3</version>
         <relativePath/>
     </parent>
 
@@ -31,6 +31,13 @@
 
     <name>Pantheon Technologies :: TrieMap</name>
     <description>Java implementation of a concurrent trie hash map from Scala collections library</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FailedNodeTest {


### PR DESCRIPTION
We are not using odlparent-4 features, hence we can get by with
version 3.1.3 instead.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>