### PR TITLE
Enable html5 javadoc

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -92,6 +92,25 @@
                   </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- On JDK9-and-later specify html5 javadoc -->
+            <id>jdk9-javadoc</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration combine.children="append">
+                            <additionalOptions>
+                                <additionalOption>-html5</additionalOption>
+                            </additionalOptions>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <licenses>


### PR DESCRIPTION
For JDK9+ we can enable html5 javadoc.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>