### PR TITLE
Enable build on Oracle JDK11 and OpenJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: java
 sudo: false
 
 jdk:
+  - openjdk8
   - oraclejdk8
+  - oraclejdk11
 before_install:
   - cp ./settings.xml $HOME/.m2/settings.xml
 script:


### PR DESCRIPTION
This adds more JDKs into the matrix.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>