### PR TITLE
Remove settings.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ jdk:
   - openjdk8
   - oraclejdk8
   - oraclejdk11
-before_install:
-  - cp ./settings.xml $HOME/.m2/settings.xml
 script:
-  - mvn -gs settings.xml clean install
+  - mvn clean install
 
 cache:
   directories:


### PR DESCRIPTION
odlparent is in maven central, we do not need settings.xml anymore.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>