### PR TITLE
Bump odparent to 4.0.6

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bundle-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.7</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Version 4.0.6 fixes SFT with Java 11, bump to it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>