### PR TITLE
Add JPMS automatic module name

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -43,6 +43,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Automatic-Module-Name>tech.pantheon.triemap</Automatic-Module-Name>
+                        <Bundle-SymbolicName>tech.pantheon.triemap</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
                     <propertyExpansion>checkstyle.violationSeverity=error</propertyExpansion>


### PR DESCRIPTION
Add Automatic-Module-Name manifest entry. While we are at it, also
add a Bundle-Symbolic-Name. Closes #42.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>