### PR TITLE
Wipe cache before storing it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ script:
 cache:
   directories:
     - '$HOME/.m2/repository'
+before_cache:
+  - rm -rf $HOME/.m2/repository/tech/pantheon/triemap
 
 after_success:
   - mvn org.eluder.coveralls:coveralls-maven-plugin:report


### PR DESCRIPTION
Caching dependencies is nice, but we are also affecting the cache.
Make sure we wipe our artifacts.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>