### PR TITLE
Bump to build on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: java
 sudo: false
 
@@ -9,8 +10,7 @@ addons:
 
 jdk:
   - openjdk8
-  - oraclejdk8
-  - oraclejdk11
+  - openjdk11
 
 script:
   - mvn clean install


### PR DESCRIPTION
Drop Oracle JDK jobs in favor of Xenial with OpenJDK.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>