### PR TITLE
Generate/inject module-info.class

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -47,8 +47,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>tech.pantheon.triemap</Automatic-Module-Name>
                         <Bundle-SymbolicName>tech.pantheon.triemap</Bundle-SymbolicName>
+                        <Multi-Release>true</Multi-Release>
                     </instructions>
                 </configuration>
             </plugin>
@@ -75,6 +75,25 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
                     <failOnError>true</failOnError>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>codes.rafael.modulemaker</groupId>
+                <artifactId>modulemaker-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>inject-module</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <name>tech.pantheon.triemap</name>
+                    <exports>tech.pantheon.triemap</exports>
+                    <multirelease>true</multirelease>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This adds the configuration to create a multi-version jar, with
modulemaker-maven-plugin taking care of injecting module-info.class
instead, thus providing exact JPMS configuration.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>