### PR TITLE
Bump odlparent to 5.0.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath />
     </parent>
 

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath />
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath />
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bundle-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
This brings in latest plugin upgrades.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>