### PR TITLE
Invoke maven-modernizer

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -82,6 +82,10 @@
                     <failOnError>true</failOnError>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>codes.rafael.modulemaker</groupId>


### PR DESCRIPTION
This ensures we run modernizer, thus making sure our target
release is used to its full extent.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>