### PR TITLE
Bump javadoc plugin to 3.1.1

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -33,11 +33,6 @@
     <description>Java implementation of a concurrent trie hash map from Scala collections library</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
-    <properties>
-        <!-- https://issues.apache.org/jira/browse/MJAVADOC-591 -->
-        <source>8</source>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -46,6 +41,16 @@
     </dependencies>
 
     <build>
+        <!-- FIXME: remove this when upgrading to oldparent-5.0.2+ -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This removes the workaround and bumps javadoc plugin to 3.1.1,
marking the override for future removal.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>