### PR TITLE
Cleanup verify

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -75,7 +75,7 @@ final class CNode<K, V> extends MainNode<K, V> {
     }
 
     static VerifyException invalidElement(final BasicNode elem) {
-        throw new VerifyException("A CNode can contain only CNodes and SNodes, not %s", elem);
+        throw new VerifyException("A CNode can contain only CNodes and SNodes, not " + elem);
     }
 
     // lends itself towards being parallelizable by choosing

--- a/triemap/src/main/java/tech/pantheon/triemap/Constants.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Constants.java
@@ -45,8 +45,22 @@ final class Constants {
      */
     static final int MAX_DEPTH = 7;
 
+    /*
+     * Normally we would be deriving both LEVEL_BITS and MAX_DEPTH from HASH_BITS and BITMAP_BITS, but that would mean
+     * they would be runtime constants. We really want them to be compile-time constants. Hence we seed them manually
+     * and assert the constants are correct.
+     */
     static {
-        VerifyException.throwIf(LEVEL_BITS != (int) (Math.log(BITMAP_BITS) / Math.log(2)));
-        VerifyException.throwIf(MAX_DEPTH != (int) Math.ceil((double)HASH_BITS / LEVEL_BITS));
+        final int expectedBits = (int) (Math.log(BITMAP_BITS) / Math.log(2));
+        if (LEVEL_BITS != expectedBits) {
+            throw new AssertionError(String.format("BITMAP_BITS=%s implies LEVEL_BITS=%s, but %s found", BITMAP_BITS,
+                expectedBits, LEVEL_BITS));
+        }
+
+        final int expectedDepth = (int) Math.ceil((double)HASH_BITS / LEVEL_BITS);
+        if (MAX_DEPTH != expectedDepth) {
+            throw new AssertionError(String.format("HASH_BITS=%s and LEVEL_BITS=%s implies MAX_DEPTH=%s, but %s found",
+                HASH_BITS, LEVEL_BITS, expectedDepth, MAX_DEPTH));
+        }
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -188,7 +188,7 @@ final class INode<K, V> extends BasicNode {
     }
 
     static VerifyException invalidElement(final BasicNode elem) {
-        throw new VerifyException("An INode can host only a CNode, a TNode or an LNode, not %s", elem);
+        throw new VerifyException("An INode can host only a CNode, a TNode or an LNode, not " + elem);
     }
 
     @SuppressFBWarnings(value = "NP_OPTIONAL_RETURN_NULL",

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
@@ -123,6 +123,6 @@ abstract class LNodeEntries<K, V> extends LNodeEntry<K, V> {
             cur = cur.next();
         }
 
-        throw new VerifyException("Failed to find entry %s", entry);
+        throw new VerifyException("Failed to find entry " + entry);
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -168,8 +168,9 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     private void inserthc(final K key, final int hc, final V value) {
         // TODO: this is called from serialization only, which means we should not be observing any races,
         //       hence we should not need to pass down the entire tree, just equality (I think).
-        final boolean success = readRoot().recInsert(key, value, hc, 0, null, this);
-        VerifyException.throwIf(!success, "Concurrent modification during serialization of map %s", this);
+        if (!readRoot().recInsert(key, value, hc, 0, null, this)) {
+            throw new VerifyException("Concurrent modification during serialization of map " + this);
+        }
     }
 
     private Optional<V> insertifhc(final K key, final int hc, final V value, final Object cond) {

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -151,7 +151,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
             return (INode<K, V>) r;
         }
 
-        checkRootDescriptor(r);
+        verifyRootDescriptor(r);
         return rdcssComplete(abort);
     }
 
@@ -214,7 +214,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
                 return (INode<K, V>) r;
             }
 
-            checkRootDescriptor(r);
+            verifyRootDescriptor(r);
             final RDCSS_Descriptor<K, V> desc = (RDCSS_Descriptor<K, V>) r;
             final INode<K, V> ov = desc.old;
             final MainNode<K, V> exp = desc.expectedmain;
@@ -248,9 +248,9 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         }
     }
 
-    private static void checkRootDescriptor(final Object obj) {
+    private static void verifyRootDescriptor(final Object obj) {
         if (!(obj instanceof RDCSS_Descriptor)) {
-            throw new VerifyException("Unhandled root %s", obj);
+            throw new VerifyException("Unhandled root " + obj);
         }
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -25,12 +25,6 @@ final class VerifyException extends RuntimeException {
         super(message);
     }
 
-    static void throwIf(final boolean expression, final String format, final Object... args) {
-        if (expression) {
-            throw new VerifyException(String.format(format, args));
-        }
-    }
-
     static <T> @NonNull T throwIfNull(final @Nullable T obj) {
         if (obj == null) {
             throw new VerifyException("Unexpected null reference");

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -21,10 +21,6 @@ import org.eclipse.jdt.annotation.Nullable;
 final class VerifyException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
-    private VerifyException() {
-
-    }
-
     VerifyException(final @NonNull String message) {
         super(message);
     }
@@ -37,7 +33,7 @@ final class VerifyException extends RuntimeException {
 
     static <T> @NonNull T throwIfNull(final @Nullable T obj) {
         if (obj == null) {
-            throw new VerifyException();
+            throw new VerifyException("Unexpected null reference");
         }
         return obj;
     }

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -29,12 +29,6 @@ final class VerifyException extends RuntimeException {
         super(String.format(format, args));
     }
 
-    static void throwIf(final boolean expression) {
-        if (expression) {
-            throw new VerifyException();
-        }
-    }
-
     static void throwIf(final boolean expresison, final String format, final Object... args) {
         if (expresison) {
             throw new VerifyException(format, args);

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -25,13 +25,13 @@ final class VerifyException extends RuntimeException {
 
     }
 
-    VerifyException(final String format, final Object... args) {
-        super(String.format(format, args));
+    VerifyException(final @NonNull String message) {
+        super(message);
     }
 
-    static void throwIf(final boolean expresison, final String format, final Object... args) {
-        if (expresison) {
-            throw new VerifyException(format, args);
+    static void throwIf(final boolean expression, final String format, final Object... args) {
+        if (expression) {
+            throw new VerifyException(String.format(format, args));
         }
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -47,11 +47,4 @@ final class VerifyException extends RuntimeException {
         }
         return obj;
     }
-
-    static <T> @NonNull T throwIfNull(final @Nullable T obj, final String format, final Object... args) {
-        if (obj == null) {
-            throw new VerifyException(format, args);
-        }
-        return obj;
-    }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
@@ -32,27 +32,10 @@ public class VerifyExceptionTest {
         VerifyException.throwIfNull(null);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testThrowIfNullNullFormat() {
-        VerifyException.throwIfNull(null, null);
-    }
-
     @Test
     public void testThrowIfNullSame() {
         final Object obj = new Object();
         assertSame(obj, VerifyException.throwIfNull(obj));
-        assertSame(obj, VerifyException.throwIfNull(obj, null));
-        assertSame(obj, VerifyException.throwIfNull(obj, "foo"));
-    }
-
-    @Test
-    public void testThrowIfNullMessage() {
-        try {
-            VerifyException.throwIfNull(null, "foo %s", "foo");
-            fail("Expected exception");
-        } catch (VerifyException e) {
-            assertEquals("foo foo", e.getMessage());
-        }
     }
 
     @Test

--- a/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
@@ -22,11 +22,6 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 public class VerifyExceptionTest {
-    @Test(expected = NullPointerException.class)
-    public void testConstructNullFormat() {
-        throw new VerifyException(null);
-    }
-
     @Test(expected = VerifyException.class)
     public void testThrowIfNullSimple() {
         VerifyException.throwIfNull(null);
@@ -46,11 +41,6 @@ public class VerifyExceptionTest {
         } catch (VerifyException e) {
             assertEquals("foo foo", e.getMessage());
         }
-    }
-
-    @Test
-    public void testThrowIfFalse() {
-        VerifyException.throwIf(false, null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
@@ -15,9 +15,7 @@
  */
 package tech.pantheon.triemap;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -31,20 +29,5 @@ public class VerifyExceptionTest {
     public void testThrowIfNullSame() {
         final Object obj = new Object();
         assertSame(obj, VerifyException.throwIfNull(obj));
-    }
-
-    @Test
-    public void testThrowIfMessage() {
-        try {
-            VerifyException.throwIf(true, "foo %s", "foo");
-            fail("Expected exception");
-        } catch (VerifyException e) {
-            assertEquals("foo foo", e.getMessage());
-        }
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testThrowIfTrueNullFormat() {
-        VerifyException.throwIf(true, null);
     }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
@@ -50,13 +50,7 @@ public class VerifyExceptionTest {
 
     @Test
     public void testThrowIfFalse() {
-        VerifyException.throwIf(false);
         VerifyException.throwIf(false, null);
-    }
-
-    @Test(expected = VerifyException.class)
-    public void testThrowIfTrue() {
-        VerifyException.throwIf(true);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
As it turns out we can clean up our infra around throwing VerifyExceptions, so that it is a tad more concise and/or not used where alternatives exist.