### PR TITLE
Fix references to Pantheon Technologies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi: set et smarttab sw=4 tabstop=4: -->
 <!--
- (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Pantheon Technologies :: TrieMap :: Bill of Materials</name>
+    <name>PANTHEON.tech :: TrieMap :: Bill of Materials</name>
     <description>Bill of Materials POM for the TrieMap project</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
@@ -92,7 +92,7 @@
             <id>rovarga</id>
             <name>Robert Varga</name>
             <email>robert.varga@pantheon.tech</email>
-            <organization>Pantheon Technologies, s.r.o.</organization>
+            <organization>PANTHEON.tech, s.r.o.</organization>
             <organizationUrl>https://www.pantheon.tech</organizationUrl>
         </developer>
     </developers>

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi: set et smarttab sw=4 tabstop=4: -->
 <!--
- (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
     <artifactId>dependency-check</artifactId>
     <version>1.1.0-SNAPSHOT</version>
 
-    <name>Pantheon Technologies :: TrieMap :: Dependency Check</name>
+    <name>PANTHEON.tech :: TrieMap :: Dependency Check</name>
     <description>Artifact for validating the contents of BOM</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
@@ -95,7 +95,7 @@
             <id>rovarga</id>
             <name>Robert Varga</name>
             <email>robert.varga@pantheon.tech</email>
-            <organization>Pantheon Technologies, s.r.o.</organization>
+            <organization>PANTHEON.tech, s.r.o.</organization>
             <organizationUrl>https://www.pantheon.tech</organizationUrl>
         </developer>
     </developers>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi: set et smarttab sw=4 tabstop=4: -->
 <!--
- (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Pantheon Technologies :: TrieMap :: Aggregator</name>
+    <name>PANTHEON.tech :: TrieMap :: Aggregator</name>
     <description>Project top-level aggregator POM</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
@@ -106,7 +106,7 @@
             <id>rovarga</id>
             <name>Robert Varga</name>
             <email>robert.varga@pantheon.tech</email>
-            <organization>Pantheon Technologies, s.r.o.</organization>
+            <organization>PANTHEON.tech, s.r.o.</organization>
             <organizationUrl>https://www.pantheon.tech</organizationUrl>
         </developer>
     </developers>

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi: set et smarttab sw=4 tabstop=4: -->
 <!--
- (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>feature</packaging>
 
-    <name>Pantheon Technologies :: TrieMap :: Feature</name>
+    <name>PANTHEON.tech :: TrieMap :: Feature</name>
     <description>Concurrent Hash-trie Map</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
@@ -95,7 +95,7 @@
             <id>rovarga</id>
             <name>Robert Varga</name>
             <email>robert.varga@pantheon.tech</email>
-            <organization>Pantheon Technologies, s.r.o.</organization>
+            <organization>PANTHEON.tech, s.r.o.</organization>
             <organizationUrl>https://www.pantheon.tech</organizationUrl>
         </developer>
     </developers>

--- a/settings.xml
+++ b/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi: set et smarttab sw=4 tabstop=4: -->
 <!--
- (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi: set et smarttab sw=4 tabstop=4: -->
 <!--
- (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
-    <name>Pantheon Technologies :: TrieMap</name>
+    <name>PANTHEON.tech :: TrieMap</name>
     <description>Java implementation of a concurrent trie hash map from Scala collections library</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
@@ -155,7 +155,7 @@
             <id>rovarga</id>
             <name>Robert Varga</name>
             <email>robert.varga@pantheon.tech</email>
-            <organization>Pantheon Technologies, s.r.o.</organization>
+            <organization>PANTHEON.tech, s.r.o.</organization>
             <organizationUrl>https://www.pantheon.tech</organizationUrl>
         </developer>
     </developers>

--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/BasicNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/BasicNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/Constants.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Constants.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/EntryNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/EntryNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/EntryUtil.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/EntryUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/Equivalence.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Equivalence.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/FailedNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/FailedNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/Gen.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Gen.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableIterator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableKeySet.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/LookupResult.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LookupResult.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/PresencePredicate.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/PresencePredicate.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/TNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/main/java/tech/pantheon/triemap/package-info.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/CNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/CNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/EntryUtilTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/EntryUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/EquivalenceTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/EquivalenceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/INodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/INodeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/ImmutableEntrySetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/ImmutableEntrySetTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/ImmutableKeySetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/ImmutableKeySetTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/ImmutableTrieMapTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/ImmutableTrieMapTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/LNodeEntriesTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/LNodeEntriesTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/LNodeEntryTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/LNodeEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/MutableEntrySetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableEntrySetTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/MutableIteratorTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/MutableKeySetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableKeySetTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/SNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/SNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/SnapshotTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/SnapshotTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2017 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestCNodeFlagCollision.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestCNodeFlagCollision.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestCNodeInsertionIncorrectOrder.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestCNodeInsertionIncorrectOrder.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapPutIfAbsent.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapPutIfAbsent.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapRemove.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapRemove.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapReplace.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapReplace.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestDelete.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestDelete.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestHashCollisions.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestHashCollisions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestHashCollisionsRemove.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestHashCollisionsRemove.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestHashCollisionsRemoveIterator.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestHashCollisionsRemoveIterator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestInsert.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestInsert.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestInstantiationSpeed.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestInstantiationSpeed.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestMapIterator.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestMapIterator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestMultiThreadAddDelete.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestMultiThreadAddDelete.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestMultiThreadInserts.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestMultiThreadInserts.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestMultiThreadMapIterator.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestMultiThreadMapIterator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestReadOnlyAndUpdatableIterators.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestReadOnlyAndUpdatableIterators.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/TestSerialization.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestSerialization.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/VerifyExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2018 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/triemap/src/test/java/tech/pantheon/triemap/ZeroHashInt.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/ZeroHashInt.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Pantheon Technologies, s.r.o. and others.
+ * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The name has changed to PANTHEON.tech, make sure we references
are updated accordingly.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>