### PR TITLE
Make target-ide ignored across the board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 **/target
+**/target-ide/
 .idea
 .classpath
 .project
@@ -7,5 +8,3 @@
 *.iml
 *.ipr
 *.iws
-
-/target-ide/


### PR DESCRIPTION
odlparent separates Eclipse into target-ide, this makes the
exclusion work throughout the workspace.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>