### PR TITLE
Bump versions to 1.2.0-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>bom</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PANTHEON.tech :: TrieMap :: Bill of Materials</name>
@@ -39,12 +39,12 @@
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>triemap</artifactId>
-                <version>1.1.1-SNAPSHOT</version>
+                <version>1.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>pt-triemap</artifactId>
-                <version>1.1.1-SNAPSHOT</version>
+                <version>1.2.0-SNAPSHOT</version>
                 <type>xml</type>
                 <classifier>features</classifier>
             </dependency>

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>dependency-check</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <name>PANTHEON.tech :: TrieMap :: Dependency Check</name>
     <description>Artifact for validating the contents of BOM</description>
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>bom</artifactId>
-                <version>1.1.1-SNAPSHOT</version>
+                <version>1.2.0-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>triemap-aggregator</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PANTHEON.tech :: TrieMap :: Aggregator</name>

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>pt-triemap</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>feature</packaging>
 
     <name>PANTHEON.tech :: TrieMap :: Feature</name>
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>bom</artifactId>
-                <version>1.1.1-SNAPSHOT</version>
+                <version>1.2.0-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>triemap</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>PANTHEON.tech :: TrieMap</name>


### PR DESCRIPTION
We are breaking compatibility with Java 8, hence bumping at least
minor version is appropriate. Versions 1.1.x will be supported on
a separate branch.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>