### PR TITLE
Remove unneeded javadoc override

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -41,16 +41,6 @@
     </dependencies>
 
     <build>
-        <!-- FIXME: remove this when upgrading to oldparent-5.0.2+ -->
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
We have upgrade to odlparent-5.0.2, which has this version, hence
we can remove the override.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>